### PR TITLE
Allow displaying an SVG logo using svg source

### DIFF
--- a/Example/ios/Podfile.lock
+++ b/Example/ios/Podfile.lock
@@ -2,14 +2,14 @@ PODS:
   - boost (1.83.0)
   - CocoaAsyncSocket (7.6.5)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.73.6)
-  - FBReactNativeSpec (0.73.6):
+  - FBLazyVector (0.73.9)
+  - FBReactNativeSpec (0.73.9):
     - RCT-Folly (= 2022.05.16.00)
-    - RCTRequired (= 0.73.6)
-    - RCTTypeSafety (= 0.73.6)
-    - React-Core (= 0.73.6)
-    - React-jsi (= 0.73.6)
-    - ReactCommon/turbomodule/core (= 0.73.6)
+    - RCTRequired (= 0.73.9)
+    - RCTTypeSafety (= 0.73.9)
+    - React-Core (= 0.73.9)
+    - React-jsi (= 0.73.9)
+    - ReactCommon/turbomodule/core (= 0.73.9)
   - Flipper (0.201.0):
     - Flipper-Folly (~> 2.6)
   - Flipper-Boost-iOSX (1.76.0.1.11)
@@ -68,9 +68,9 @@ PODS:
     - FlipperKit/FlipperKitNetworkPlugin
   - fmt (6.2.1)
   - glog (0.3.5)
-  - hermes-engine (0.73.6):
-    - hermes-engine/Pre-built (= 0.73.6)
-  - hermes-engine/Pre-built (0.73.6)
+  - hermes-engine (0.73.9):
+    - hermes-engine/Pre-built (= 0.73.9)
+  - hermes-engine/Pre-built (0.73.9)
   - libevent (2.1.12)
   - OpenSSL-Universal (1.1.1100)
   - RCT-Folly (2022.05.16.00):
@@ -95,26 +95,26 @@ PODS:
     - fmt (~> 6.2.1)
     - glog
     - libevent
-  - RCTRequired (0.73.6)
-  - RCTTypeSafety (0.73.6):
-    - FBLazyVector (= 0.73.6)
-    - RCTRequired (= 0.73.6)
-    - React-Core (= 0.73.6)
-  - React (0.73.6):
-    - React-Core (= 0.73.6)
-    - React-Core/DevSupport (= 0.73.6)
-    - React-Core/RCTWebSocket (= 0.73.6)
-    - React-RCTActionSheet (= 0.73.6)
-    - React-RCTAnimation (= 0.73.6)
-    - React-RCTBlob (= 0.73.6)
-    - React-RCTImage (= 0.73.6)
-    - React-RCTLinking (= 0.73.6)
-    - React-RCTNetwork (= 0.73.6)
-    - React-RCTSettings (= 0.73.6)
-    - React-RCTText (= 0.73.6)
-    - React-RCTVibration (= 0.73.6)
-  - React-callinvoker (0.73.6)
-  - React-Codegen (0.73.6):
+  - RCTRequired (0.73.9)
+  - RCTTypeSafety (0.73.9):
+    - FBLazyVector (= 0.73.9)
+    - RCTRequired (= 0.73.9)
+    - React-Core (= 0.73.9)
+  - React (0.73.9):
+    - React-Core (= 0.73.9)
+    - React-Core/DevSupport (= 0.73.9)
+    - React-Core/RCTWebSocket (= 0.73.9)
+    - React-RCTActionSheet (= 0.73.9)
+    - React-RCTAnimation (= 0.73.9)
+    - React-RCTBlob (= 0.73.9)
+    - React-RCTImage (= 0.73.9)
+    - React-RCTLinking (= 0.73.9)
+    - React-RCTNetwork (= 0.73.9)
+    - React-RCTSettings (= 0.73.9)
+    - React-RCTText (= 0.73.9)
+    - React-RCTVibration (= 0.73.9)
+  - React-callinvoker (0.73.9)
+  - React-Codegen (0.73.9):
     - DoubleConversion
     - FBReactNativeSpec
     - glog
@@ -129,11 +129,11 @@ PODS:
     - React-rncore
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-Core (0.73.6):
+  - React-Core (0.73.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.6)
+    - React-Core/Default (= 0.73.9)
     - React-cxxreact
     - React-hermes
     - React-jsi
@@ -143,50 +143,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.73.6):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default
-    - React-cxxreact
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.6.1)
-    - Yoga
-  - React-Core/Default (0.73.6):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2022.05.16.00)
-    - React-cxxreact
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.6.1)
-    - Yoga
-  - React-Core/DevSupport (0.73.6):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.6)
-    - React-Core/RCTWebSocket (= 0.73.6)
-    - React-cxxreact
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector (= 0.73.6)
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.6.1)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.73.6):
+  - React-Core/CoreModulesHeaders (0.73.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -200,7 +157,36 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.73.6):
+  - React-Core/Default (0.73.9):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2022.05.16.00)
+    - React-cxxreact
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.6.1)
+    - Yoga
+  - React-Core/DevSupport (0.73.9):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2022.05.16.00)
+    - React-Core/Default (= 0.73.9)
+    - React-Core/RCTWebSocket (= 0.73.9)
+    - React-cxxreact
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector (= 0.73.9)
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.6.1)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.73.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -214,7 +200,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.73.6):
+  - React-Core/RCTAnimationHeaders (0.73.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -228,7 +214,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTImageHeaders (0.73.6):
+  - React-Core/RCTBlobHeaders (0.73.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -242,7 +228,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.73.6):
+  - React-Core/RCTImageHeaders (0.73.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -256,7 +242,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.73.6):
+  - React-Core/RCTLinkingHeaders (0.73.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -270,7 +256,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.73.6):
+  - React-Core/RCTNetworkHeaders (0.73.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -284,7 +270,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTTextHeaders (0.73.6):
+  - React-Core/RCTSettingsHeaders (0.73.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -298,7 +284,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.73.6):
+  - React-Core/RCTTextHeaders (0.73.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -312,11 +298,11 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-Core/RCTWebSocket (0.73.6):
+  - React-Core/RCTVibrationHeaders (0.73.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.6)
+    - React-Core/Default
     - React-cxxreact
     - React-hermes
     - React-jsi
@@ -326,33 +312,47 @@ PODS:
     - React-utils
     - SocketRocket (= 0.6.1)
     - Yoga
-  - React-CoreModules (0.73.6):
+  - React-Core/RCTWebSocket (0.73.9):
+    - glog
+    - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
-    - RCTTypeSafety (= 0.73.6)
+    - React-Core/Default (= 0.73.9)
+    - React-cxxreact
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.6.1)
+    - Yoga
+  - React-CoreModules (0.73.9):
+    - RCT-Folly (= 2022.05.16.00)
+    - RCTTypeSafety (= 0.73.9)
     - React-Codegen
-    - React-Core/CoreModulesHeaders (= 0.73.6)
-    - React-jsi (= 0.73.6)
+    - React-Core/CoreModulesHeaders (= 0.73.9)
+    - React-jsi (= 0.73.9)
     - React-NativeModulesApple
     - React-RCTBlob
-    - React-RCTImage (= 0.73.6)
+    - React-RCTImage (= 0.73.9)
     - ReactCommon
     - SocketRocket (= 0.6.1)
-  - React-cxxreact (0.73.6):
+  - React-cxxreact (0.73.9):
     - boost (= 1.83.0)
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.6)
-    - React-debug (= 0.73.6)
-    - React-jsi (= 0.73.6)
-    - React-jsinspector (= 0.73.6)
-    - React-logger (= 0.73.6)
-    - React-perflogger (= 0.73.6)
-    - React-runtimeexecutor (= 0.73.6)
-  - React-debug (0.73.6)
-  - React-Fabric (0.73.6):
+    - React-callinvoker (= 0.73.9)
+    - React-debug (= 0.73.9)
+    - React-jsi (= 0.73.9)
+    - React-jsinspector (= 0.73.9)
+    - React-logger (= 0.73.9)
+    - React-perflogger (= 0.73.9)
+    - React-runtimeexecutor (= 0.73.9)
+  - React-debug (0.73.9)
+  - React-Fabric (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -363,20 +363,20 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.73.6)
-    - React-Fabric/attributedstring (= 0.73.6)
-    - React-Fabric/componentregistry (= 0.73.6)
-    - React-Fabric/componentregistrynative (= 0.73.6)
-    - React-Fabric/components (= 0.73.6)
-    - React-Fabric/core (= 0.73.6)
-    - React-Fabric/imagemanager (= 0.73.6)
-    - React-Fabric/leakchecker (= 0.73.6)
-    - React-Fabric/mounting (= 0.73.6)
-    - React-Fabric/scheduler (= 0.73.6)
-    - React-Fabric/telemetry (= 0.73.6)
-    - React-Fabric/templateprocessor (= 0.73.6)
-    - React-Fabric/textlayoutmanager (= 0.73.6)
-    - React-Fabric/uimanager (= 0.73.6)
+    - React-Fabric/animations (= 0.73.9)
+    - React-Fabric/attributedstring (= 0.73.9)
+    - React-Fabric/componentregistry (= 0.73.9)
+    - React-Fabric/componentregistrynative (= 0.73.9)
+    - React-Fabric/components (= 0.73.9)
+    - React-Fabric/core (= 0.73.9)
+    - React-Fabric/imagemanager (= 0.73.9)
+    - React-Fabric/leakchecker (= 0.73.9)
+    - React-Fabric/mounting (= 0.73.9)
+    - React-Fabric/scheduler (= 0.73.9)
+    - React-Fabric/telemetry (= 0.73.9)
+    - React-Fabric/templateprocessor (= 0.73.9)
+    - React-Fabric/textlayoutmanager (= 0.73.9)
+    - React-Fabric/uimanager (= 0.73.9)
     - React-graphics
     - React-jsi
     - React-jsiexecutor
@@ -385,26 +385,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/animations (0.73.6):
-    - DoubleConversion
-    - fmt (~> 6.2.1)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2022.05.16.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/attributedstring (0.73.6):
+  - React-Fabric/animations (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -423,7 +404,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistry (0.73.6):
+  - React-Fabric/attributedstring (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -442,7 +423,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistrynative (0.73.6):
+  - React-Fabric/componentregistry (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -461,37 +442,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components (0.73.6):
-    - DoubleConversion
-    - fmt (~> 6.2.1)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2022.05.16.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/inputaccessory (= 0.73.6)
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.73.6)
-    - React-Fabric/components/modal (= 0.73.6)
-    - React-Fabric/components/rncore (= 0.73.6)
-    - React-Fabric/components/root (= 0.73.6)
-    - React-Fabric/components/safeareaview (= 0.73.6)
-    - React-Fabric/components/scrollview (= 0.73.6)
-    - React-Fabric/components/text (= 0.73.6)
-    - React-Fabric/components/textinput (= 0.73.6)
-    - React-Fabric/components/unimplementedview (= 0.73.6)
-    - React-Fabric/components/view (= 0.73.6)
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/components/inputaccessory (0.73.6):
+  - React-Fabric/componentregistrynative (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -510,7 +461,37 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/legacyviewmanagerinterop (0.73.6):
+  - React-Fabric/components (0.73.9):
+    - DoubleConversion
+    - fmt (~> 6.2.1)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/inputaccessory (= 0.73.9)
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.73.9)
+    - React-Fabric/components/modal (= 0.73.9)
+    - React-Fabric/components/rncore (= 0.73.9)
+    - React-Fabric/components/root (= 0.73.9)
+    - React-Fabric/components/safeareaview (= 0.73.9)
+    - React-Fabric/components/scrollview (= 0.73.9)
+    - React-Fabric/components/text (= 0.73.9)
+    - React-Fabric/components/textinput (= 0.73.9)
+    - React-Fabric/components/unimplementedview (= 0.73.9)
+    - React-Fabric/components/view (= 0.73.9)
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/inputaccessory (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -529,7 +510,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/modal (0.73.6):
+  - React-Fabric/components/legacyviewmanagerinterop (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -548,7 +529,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/rncore (0.73.6):
+  - React-Fabric/components/modal (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -567,7 +548,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/root (0.73.6):
+  - React-Fabric/components/rncore (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -586,7 +567,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/safeareaview (0.73.6):
+  - React-Fabric/components/root (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -605,7 +586,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/scrollview (0.73.6):
+  - React-Fabric/components/safeareaview (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -624,7 +605,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/text (0.73.6):
+  - React-Fabric/components/scrollview (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -643,7 +624,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/textinput (0.73.6):
+  - React-Fabric/components/text (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -662,7 +643,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/unimplementedview (0.73.6):
+  - React-Fabric/components/textinput (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -681,7 +662,26 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/view (0.73.6):
+  - React-Fabric/components/unimplementedview (0.73.9):
+    - DoubleConversion
+    - fmt (~> 6.2.1)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2022.05.16.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/view (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -701,7 +701,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric/core (0.73.6):
+  - React-Fabric/core (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -720,7 +720,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/imagemanager (0.73.6):
+  - React-Fabric/imagemanager (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -739,7 +739,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/leakchecker (0.73.6):
+  - React-Fabric/leakchecker (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -758,7 +758,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/mounting (0.73.6):
+  - React-Fabric/mounting (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -777,7 +777,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/scheduler (0.73.6):
+  - React-Fabric/scheduler (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -796,7 +796,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/telemetry (0.73.6):
+  - React-Fabric/telemetry (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -815,7 +815,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/templateprocessor (0.73.6):
+  - React-Fabric/templateprocessor (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -834,7 +834,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/textlayoutmanager (0.73.6):
+  - React-Fabric/textlayoutmanager (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -854,7 +854,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager (0.73.6):
+  - React-Fabric/uimanager (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
@@ -873,42 +873,42 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-FabricImage (0.73.6):
+  - React-FabricImage (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
-    - RCTRequired (= 0.73.6)
-    - RCTTypeSafety (= 0.73.6)
+    - RCTRequired (= 0.73.9)
+    - RCTTypeSafety (= 0.73.9)
     - React-Fabric
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.73.6)
+    - React-jsiexecutor (= 0.73.9)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - Yoga
-  - React-graphics (0.73.6):
+  - React-graphics (0.73.9):
     - glog
     - RCT-Folly/Fabric (= 2022.05.16.00)
-    - React-Core/Default (= 0.73.6)
+    - React-Core/Default (= 0.73.9)
     - React-utils
-  - React-hermes (0.73.6):
+  - React-hermes (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
     - RCT-Folly/Futures (= 2022.05.16.00)
-    - React-cxxreact (= 0.73.6)
+    - React-cxxreact (= 0.73.9)
     - React-jsi
-    - React-jsiexecutor (= 0.73.6)
-    - React-jsinspector (= 0.73.6)
-    - React-perflogger (= 0.73.6)
-  - React-ImageManager (0.73.6):
+    - React-jsiexecutor (= 0.73.9)
+    - React-jsinspector (= 0.73.9)
+    - React-perflogger (= 0.73.9)
+  - React-ImageManager (0.73.9):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -917,35 +917,35 @@ PODS:
     - React-graphics
     - React-rendererdebug
     - React-utils
-  - React-jserrorhandler (0.73.6):
+  - React-jserrorhandler (0.73.9):
     - RCT-Folly/Fabric (= 2022.05.16.00)
     - React-debug
     - React-jsi
     - React-Mapbuffer
-  - React-jsi (0.73.6):
+  - React-jsi (0.73.9):
     - boost (= 1.83.0)
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
-  - React-jsiexecutor (0.73.6):
+  - React-jsiexecutor (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
-    - React-cxxreact (= 0.73.6)
-    - React-jsi (= 0.73.6)
-    - React-perflogger (= 0.73.6)
-  - React-jsinspector (0.73.6)
-  - React-logger (0.73.6):
+    - React-cxxreact (= 0.73.9)
+    - React-jsi (= 0.73.9)
+    - React-perflogger (= 0.73.9)
+  - React-jsinspector (0.73.9)
+  - React-logger (0.73.9):
     - glog
-  - React-Mapbuffer (0.73.6):
+  - React-Mapbuffer (0.73.9):
     - glog
     - React-debug
-  - React-nativeconfig (0.73.6)
-  - React-NativeModulesApple (0.73.6):
+  - React-nativeconfig (0.73.9)
+  - React-NativeModulesApple (0.73.9):
     - glog
     - hermes-engine
     - React-callinvoker
@@ -955,10 +955,10 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.73.6)
-  - React-RCTActionSheet (0.73.6):
-    - React-Core/RCTActionSheetHeaders (= 0.73.6)
-  - React-RCTAnimation (0.73.6):
+  - React-perflogger (0.73.9)
+  - React-RCTActionSheet (0.73.9):
+    - React-Core/RCTActionSheetHeaders (= 0.73.9)
+  - React-RCTAnimation (0.73.9):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -966,7 +966,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTAppDelegate (0.73.6):
+  - React-RCTAppDelegate (0.73.9):
     - RCT-Folly
     - RCTRequired
     - RCTTypeSafety
@@ -980,7 +980,7 @@ PODS:
     - React-RCTNetwork
     - React-runtimescheduler
     - ReactCommon
-  - React-RCTBlob (0.73.6):
+  - React-RCTBlob (0.73.9):
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
     - React-Codegen
@@ -990,7 +990,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTFabric (0.73.6):
+  - React-RCTFabric (0.73.9):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2022.05.16.00)
@@ -1008,7 +1008,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTImage (0.73.6):
+  - React-RCTImage (0.73.9):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -1017,14 +1017,14 @@ PODS:
     - React-NativeModulesApple
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTLinking (0.73.6):
+  - React-RCTLinking (0.73.9):
     - React-Codegen
-    - React-Core/RCTLinkingHeaders (= 0.73.6)
-    - React-jsi (= 0.73.6)
+    - React-Core/RCTLinkingHeaders (= 0.73.9)
+    - React-jsi (= 0.73.9)
     - React-NativeModulesApple
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.73.6)
-  - React-RCTNetwork (0.73.6):
+    - ReactCommon/turbomodule/core (= 0.73.9)
+  - React-RCTNetwork (0.73.9):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -1032,7 +1032,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTSettings (0.73.6):
+  - React-RCTSettings (0.73.9):
     - RCT-Folly (= 2022.05.16.00)
     - RCTTypeSafety
     - React-Codegen
@@ -1040,25 +1040,25 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTText (0.73.6):
-    - React-Core/RCTTextHeaders (= 0.73.6)
+  - React-RCTText (0.73.9):
+    - React-Core/RCTTextHeaders (= 0.73.9)
     - Yoga
-  - React-RCTVibration (0.73.6):
+  - React-RCTVibration (0.73.9):
     - RCT-Folly (= 2022.05.16.00)
     - React-Codegen
     - React-Core/RCTVibrationHeaders
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-rendererdebug (0.73.6):
+  - React-rendererdebug (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - RCT-Folly (= 2022.05.16.00)
     - React-debug
-  - React-rncore (0.73.6)
-  - React-runtimeexecutor (0.73.6):
-    - React-jsi (= 0.73.6)
-  - React-runtimescheduler (0.73.6):
+  - React-rncore (0.73.9)
+  - React-runtimeexecutor (0.73.9):
+    - React-jsi (= 0.73.9)
+  - React-runtimescheduler (0.73.9):
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
@@ -1069,49 +1069,49 @@ PODS:
     - React-rendererdebug
     - React-runtimeexecutor
     - React-utils
-  - React-utils (0.73.6):
+  - React-utils (0.73.9):
     - glog
     - RCT-Folly (= 2022.05.16.00)
     - React-debug
-  - ReactCommon (0.73.6):
-    - React-logger (= 0.73.6)
-    - ReactCommon/turbomodule (= 0.73.6)
-  - ReactCommon/turbomodule (0.73.6):
+  - ReactCommon (0.73.9):
+    - React-logger (= 0.73.9)
+    - ReactCommon/turbomodule (= 0.73.9)
+  - ReactCommon/turbomodule (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.6)
-    - React-cxxreact (= 0.73.6)
-    - React-jsi (= 0.73.6)
-    - React-logger (= 0.73.6)
-    - React-perflogger (= 0.73.6)
-    - ReactCommon/turbomodule/bridging (= 0.73.6)
-    - ReactCommon/turbomodule/core (= 0.73.6)
-  - ReactCommon/turbomodule/bridging (0.73.6):
+    - React-callinvoker (= 0.73.9)
+    - React-cxxreact (= 0.73.9)
+    - React-jsi (= 0.73.9)
+    - React-logger (= 0.73.9)
+    - React-perflogger (= 0.73.9)
+    - ReactCommon/turbomodule/bridging (= 0.73.9)
+    - ReactCommon/turbomodule/core (= 0.73.9)
+  - ReactCommon/turbomodule/bridging (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.6)
-    - React-cxxreact (= 0.73.6)
-    - React-jsi (= 0.73.6)
-    - React-logger (= 0.73.6)
-    - React-perflogger (= 0.73.6)
-  - ReactCommon/turbomodule/core (0.73.6):
+    - React-callinvoker (= 0.73.9)
+    - React-cxxreact (= 0.73.9)
+    - React-jsi (= 0.73.9)
+    - React-logger (= 0.73.9)
+    - React-perflogger (= 0.73.9)
+  - ReactCommon/turbomodule/core (0.73.9):
     - DoubleConversion
     - fmt (~> 6.2.1)
     - glog
     - hermes-engine
     - RCT-Folly (= 2022.05.16.00)
-    - React-callinvoker (= 0.73.6)
-    - React-cxxreact (= 0.73.6)
-    - React-jsi (= 0.73.6)
-    - React-logger (= 0.73.6)
-    - React-perflogger (= 0.73.6)
-  - RNSVG (15.1.0):
+    - React-callinvoker (= 0.73.9)
+    - React-cxxreact (= 0.73.9)
+    - React-jsi (= 0.73.9)
+    - React-logger (= 0.73.9)
+    - React-perflogger (= 0.73.9)
+  - RNSVG (15.5.0):
     - React-Core
   - SocketRocket (0.6.1)
   - Yoga (1.14.0)
@@ -1221,7 +1221,7 @@ EXTERNAL SOURCES:
     :podspec: "../node_modules/react-native/third-party-podspecs/glog.podspec"
   hermes-engine:
     :podspec: "../node_modules/react-native/sdks/hermes-engine/hermes-engine.podspec"
-    :tag: hermes-2024-02-20-RNv0.73.5-18f99ace4213052c5e7cdbcd39ee9766cd5df7e4
+    :tag: hermes-2024-04-29-RNv0.73.8-644c8be78af1eae7c138fa4093fb87f0f4f8db85
   RCT-Folly:
     :podspec: "../node_modules/react-native/third-party-podspecs/RCT-Folly.podspec"
   RCTRequired:
@@ -1313,8 +1313,8 @@ SPEC CHECKSUMS:
   boost: d3f49c53809116a5d38da093a8aa78bf551aed09
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: fea03f2699887d960129cc54bba7e52542b6f953
-  FBLazyVector: f64d1e2ea739b4d8f7e4740cde18089cd97fe864
-  FBReactNativeSpec: 9f2b8b243131565335437dba74923a8d3015e780
+  FBLazyVector: 98c189b92292d4bfeac13ffa8df3ce3d84e2fc5b
+  FBReactNativeSpec: 4fe1d8c2fadc7949344b197d933f76b40401aac5
   Flipper: c7a0093234c4bdd456e363f2f19b2e4b27652d44
   Flipper-Boost-iOSX: fd1e2b8cbef7e662a122412d7ac5f5bea715403c
   Flipper-DoubleConversion: 2dc99b02f658daf147069aad9dbd29d8feb06d30
@@ -1325,53 +1325,53 @@ SPEC CHECKSUMS:
   FlipperKit: 37525a5d056ef9b93d1578e04bc3ea1de940094f
   fmt: ff9d55029c625d3757ed641535fd4a75fedc7ce9
   glog: c5d68082e772fa1c511173d6b30a9de2c05a69a2
-  hermes-engine: 9cecf9953a681df7556b8cc9c74905de8f3293c0
+  hermes-engine: ed62e0dcd013bf4a3b487f164feec1c4e705b5b5
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
   RCT-Folly: 7169b2b1c44399c76a47b5deaaba715eeeb476c0
-  RCTRequired: ca1d7414aba0b27efcfa2ccd37637edb1ab77d96
-  RCTTypeSafety: 678e344fb976ff98343ca61dc62e151f3a042292
-  React: e296bcebb489deaad87326067204eb74145934ab
-  React-callinvoker: d0b7015973fa6ccb592bb0363f6bc2164238ab8c
-  React-Codegen: f034a5de6f28e15e8d95d171df17e581d5309268
-  React-Core: 44c936d0ab879e9c32e5381bd7596a677c59c974
-  React-CoreModules: 558228e12cddb9ca00ff7937894cc5104a21be6b
-  React-cxxreact: 1fcf565012c203655b3638f35aa03c13c2ed7e9e
-  React-debug: d444db402065cca460d9c5b072caab802a04f729
-  React-Fabric: 7d11905695e42f8bdaedddcf294959b43b290ab8
-  React-FabricImage: 6e06a512d2fb5f55669c721578736785d915d4f5
-  React-graphics: 5500206f7c9a481456365403c9fcf1638de108b7
-  React-hermes: 783023e43af9d6be4fbaeeb96b5beee00649a5f7
-  React-ImageManager: df193215ff3cf1a8dad297e554c89c632e42436c
-  React-jserrorhandler: a4d0f541c5852cf031db2f82f51de90be55b1334
-  React-jsi: ae102ccb38d2e4d0f512b7074d0c9b4e1851f402
-  React-jsiexecutor: bd12ec75873d3ef0a755c11f878f2c420430f5a9
-  React-jsinspector: 85583ef014ce53d731a98c66a0e24496f7a83066
-  React-logger: 3eb80a977f0d9669468ef641a5e1fabbc50a09ec
-  React-Mapbuffer: 84ea43c6c6232049135b1550b8c60b2faac19fab
-  React-nativeconfig: b4d4e9901d4cabb57be63053fd2aa6086eb3c85f
-  React-NativeModulesApple: cd26e56d56350e123da0c1e3e4c76cb58a05e1ee
-  React-perflogger: 5f49905de275bac07ac7ea7f575a70611fa988f2
-  React-RCTActionSheet: 37edf35aeb8e4f30e76c82aab61f12d1b75c04ec
-  React-RCTAnimation: a69de7f3daa8462743094f4736c455e844ea63f7
-  React-RCTAppDelegate: 51fb96b554a6acd0cd7818acecd5aa5ca2f3ab9f
-  React-RCTBlob: d91771caebf2d015005d750cd1dc2b433ad07c99
-  React-RCTFabric: c5b9451d1f2b546119b7a0353226a8a26247d4a9
-  React-RCTImage: a0bfe87b6908c7b76bd7d74520f40660bd0ad881
-  React-RCTLinking: 5f10be1647952cceddfa1970fdb374087582fc34
-  React-RCTNetwork: a0bc3dd45a2dc7c879c80cebb6f9707b2c8bbed6
-  React-RCTSettings: 28c202b68afa59afb4067510f2c69c5a530fb9e3
-  React-RCTText: 4119d9e53ca5db9502b916e1b146e99798986d21
-  React-RCTVibration: 55bd7c48487eb9a2562f2bd3fdc833274f5b0636
-  React-rendererdebug: 5fa97ba664806cee4700e95aec42dff1b6f8ea36
-  React-rncore: b0a8e1d14dabb7115c7a5b4ec8b9b74d1727d382
-  React-runtimeexecutor: bb328dbe2865f3a550df0240df8e2d8c3aaa4c57
-  React-runtimescheduler: 9636eee762c699ca7c85751a359101797e4c8b3b
-  React-utils: d16c1d2251c088ad817996621947d0ac8167b46c
-  ReactCommon: 2aa35648354bd4c4665b9a5084a7d37097b89c10
-  RNSVG: 50cf2c7018e57cf5d3522d98d0a3a4dd6bf9d093
+  RCTRequired: d362a61864a64315aee00faea8dee6cf5b3f4aad
+  RCTTypeSafety: 09baf60faeab02492dc8bf04ce5af1dda645b86d
+  React: b87c7c7c12f8232bd7cfdc4a00bf687144c17e30
+  React-callinvoker: 67de0bc05ecb7e690345a53a1661cea9b24670b0
+  React-Codegen: d4acea6cf2a7889c042653eaff9233b1d6c4d3c3
+  React-Core: 4c87a1873c6d11c6d3843582fbc266ba9ea304ce
+  React-CoreModules: 29ad1cbe757a70575913457bb7c646b7f4d4edf0
+  React-cxxreact: 08ffaf2def6fe1ec8ef7f16e208587c96a87978e
+  React-debug: 937e24adc0479b9bbed3f1b7e0db68688d93c31c
+  React-Fabric: 1e2eb26de25f2629350beaab7abc3623becce2b7
+  React-FabricImage: 5791bf14ff0550f26b81be575e9a10f1f3c69688
+  React-graphics: 3ba4dba54c4d1426118089f1943708ef0bba8a84
+  React-hermes: fdaab14cc289d8d9cd45ffd9a3f8aa11157d4c7e
+  React-ImageManager: 13b4aebbffd9addbcd79d1687355db2f6d8a37e2
+  React-jserrorhandler: f30af3ec30fdc04a4b080c5b1f3defb801c0c861
+  React-jsi: 2253621cb2fb5d43a78fec4db8989cf9711039df
+  React-jsiexecutor: 5e4620a87fbc4ab174d75220f06ba8b53ae8317b
+  React-jsinspector: aee04d04ef553d5e30e52a4de2af958cb060069f
+  React-logger: 87a4232dd55485435edfa6803ff0de0b5c9eea1a
+  React-Mapbuffer: 6c229dc8f1640457d1f665f0b7d79ab8f604dc8b
+  React-nativeconfig: c1729ab95240ec80d47a2bb8354d8f31138e35a7
+  React-NativeModulesApple: 115c934a87f3b45fecb0fada08fa70bab3dff65c
+  React-perflogger: c93b6a895eca3f9196656bb20ce0e15ad597a4e9
+  React-RCTActionSheet: 258842f426709dccbc2af31ca42b0a1807d76ad7
+  React-RCTAnimation: 78c40269e35864f541b7486d17bd82a353c99fbc
+  React-RCTAppDelegate: d98ec2cdfb161d7a8496990e9649f94018025922
+  React-RCTBlob: 593a5dbc58c45e3cccc37ad4498b10766ace26e6
+  React-RCTFabric: e6060e78040264f8a542bb8631ae1bbfd5a882ed
+  React-RCTImage: a0cdbb81db012ebc42c7dbaabdcb15f488c7c391
+  React-RCTLinking: 82b6b0a5b2d5c8d3a28997e70bda46bac4be4c6e
+  React-RCTNetwork: 45e30079bcb987724028c9a93c0110b6d82e4a1f
+  React-RCTSettings: e67cbe694fe45b080b96b1394d4e45dff1b3ae04
+  React-RCTText: 14a54686a1fa0b51b76660c7700980fdec6c3093
+  React-RCTVibration: 00561f3d12dca44ed55af9060752bf8cf3fb0bfc
+  React-rendererdebug: 975f3e6e430ba1a9b92dc44bc99757cb1c6cae60
+  React-rncore: e7dc772ade687746b8a8a38985b4512b8d232637
+  React-runtimeexecutor: bf98e8973ed4c45139fbbaf2c34af44053acc9a9
+  React-runtimescheduler: efb26ad81d94a9b047504bd716b48869bd311649
+  React-utils: dab84549e65d6d711937b9c34d9f6d8fb8bd711c
+  ReactCommon: 3dc453f427d2f3d7f2c71499d191b456f83c59bd
+  RNSVG: b986585e367f4a49d8aa43065066cc9c290b3d9b
   SocketRocket: f32cd54efbe0f095c4d7594881e52619cfe80b17
-  Yoga: 805bf71192903b20fc14babe48080582fee65a80
+  Yoga: 57d2ffe418d024d56f8b0047f335c677e4c4d9ac
 
 PODFILE CHECKSUM: 5506db2064b9bbcf95b89a76274d9998b06e711d
 

--- a/Example/package.json
+++ b/Example/package.json
@@ -21,7 +21,7 @@
     "react-native": "^0.73.6",
     "react-native-macos": "^0.73.0-0",
     "react-native-qrcode-svg": "link:../",
-    "react-native-svg": "^15.1.0",
+    "react-native-svg": "^15.5.0",
     "react-native-web": "^0.19.10",
     "webpack": "^5.91.0"
   },

--- a/Example/src/App.tsx
+++ b/Example/src/App.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
-import {ScrollView, Text, SafeAreaView} from 'react-native';
-import styles from './styles';
+import {SafeAreaView, ScrollView, Text} from 'react-native';
+import SVG from './assets/ruby.svg';
 import Description from './components/Description';
 import QRCode from 'react-native-qrcode-svg';
+import styles from './styles';
 
+const rubyUrl = 'https://www.ruby-lang.org/';
 const googleUrl = 'https://www.google.com/';
 const qrCodeSize = 200;
 const logoSize = 100;
@@ -60,6 +62,54 @@ const localPngBackgroundColorQRCode = (
   </Description>
 );
 
+const urlSvgQRCode = (
+  <Description text="QR code with SVG from url avatar">
+    <QRCode
+      value={rubyUrl}
+      size={qrCodeSize}
+      logoSVG="https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/ruby.svg"
+      logoSize={logoSize}
+    />
+  </Description>
+);
+
+const xml = `
+  <svg viewBox='0 0 100 100' xmlns='http://www.w3.org/2000/svg'>
+    <path d='M20,100l74-5l6-75zM61,35l37-2l-29-24z' fill='#b11' fill-rule='evenodd'/>
+    <path d='M21,100l74-5l-47-4zM98,33c4-12,5-29-14-33l-15,9l29,24z' fill='#811' fill-rule='evenodd'/>
+    <path d='M7,67l14,33l11-38z' fill='#d44' fill-rule='evenodd'/>
+    <path d='M29,61l42,13l-10-42zM56,0h28l-16,10zM1,51l-1,29l7-13z' fill='#c22' fill-rule='evenodd'/>
+    <path d='M32,61l39,13c-14,13-30,24-50,26z' fill='#a00' fill-rule='evenodd'/>
+    <path d='M61,35l10,39l17-23zM32,61l16,30c9-5,16-11,23-17l-39-13z' fill='#900' fill-rule='evenodd'/>
+    <path d='M61,35l27,17l10-20l-37,3z' fill='#800' fill-rule='evenodd'/>
+    <path d='M71,74l23,21l-6-44zM0,80c1,19,15,20,21,20l-14-33l-7,13zM7,67l-2,26c4,6,9,7,15,6c-4-11-13-32-13-32zM69,9l30,4c-1-7-6-11-15-13l-15,9z' fill='#911' fill-rule='evenodd'/>
+    <path d='M1,51l6,16l25-5l29-27l8-26l-13-9l-22,8c-6,7-20,19-20,19c-1,1-9,16-13,24z' fill='#ebb' fill-rule='evenodd'/>
+    <path d='M21,21c15-14,34-23,42-16c7,8-1,26-16,40c-14,15-33,24-41,17c-7-7,1-26,15-41z' fill='#b11' fill-rule='evenodd'/>
+  </svg>
+`;
+
+const stringSvgQRCode = (
+  <Description text="QR code with raw SVG (string) avatar">
+    <QRCode
+      value={rubyUrl}
+      size={qrCodeSize}
+      logoSVG={xml}
+      logoSize={logoSize}
+    />
+  </Description>
+);
+
+const localSvgQRCode = (
+  <Description text="QR code with local SVG avatar">
+    <QRCode
+      value={rubyUrl}
+      size={qrCodeSize}
+      logoSVG={SVG}
+      logoSize={logoSize}
+    />
+  </Description>
+);
+
 const App = () => {
   return (
     <SafeAreaView>
@@ -70,6 +120,9 @@ const App = () => {
         {urlPngQRCode}
         {localPngQRCode}
         {localPngBackgroundColorQRCode}
+        {urlSvgQRCode}
+        {stringSvgQRCode}
+        {localSvgQRCode}
       </ScrollView>
     </SafeAreaView>
   );

--- a/Example/yarn.lock
+++ b/Example/yarn.lock
@@ -7324,10 +7324,10 @@ react-native-macos@^0.73.0-0:
   version "0.0.0"
   uid ""
 
-react-native-svg@^15.1.0:
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-15.6.0.tgz#13b2af53b1701597df301122b869b61918e1e9a5"
-  integrity sha512-TUtR+h+yi1ODsd8FHdom1TpjfWOmnaK5pri5rnSBXnMqpzq8o2zZfonHTjPX+nS3wb/Pu2XsoARgYaHNjVWXhQ==
+react-native-svg@15.5.0:
+  version "15.5.0"
+  resolved "https://registry.yarnpkg.com/react-native-svg/-/react-native-svg-15.5.0.tgz#208647f2f1266a0a214f16e1b807fdc3ee7c0869"
+  integrity sha512-/DUPfmSf3eXt59WjG8hlRKVPzqVjM7duG9vJH6UYAJesj3NtYcyFsO5sYpSkovlOwagk84PibcVb92bBwMSmng==
   dependencies:
     css-select "^5.1.0"
     css-tree "^1.1.3"

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import {ImageSourcePropType} from "react-native";
+import type {ImageSourcePropType} from "react-native";
 import type {SvgProps} from "react-native-svg";
 
 declare class QRCode extends React.PureComponent<QRCodeProps, any> {}
@@ -14,17 +14,18 @@ export interface QRCodeProps {
   /* the color of the background */
   backgroundColor?: string;
   /* SVG to render as logo.
-  * If this prop is provided then `logo` prop will be ignored. */
-  logoSVG?: React.FC<SvgProps>;
+  * Can be either a svg string or a React component if you're using ex: '@svgr/webpack' or similar
+  * In case both this prop and `logo` are provided, then this prop takes precedence and `logo` will be ignored. */
+  logoSVG?: React.FC<SvgProps> | string;
   /* an image source object. example {uri: 'base64string'} or {require('pathToImage')} */
-  logo?: ImageSourcePropType;
+  logo?: ImageSourcePropType | string;
   /* logo size in pixels */
   logoSize?: number;
   /* the logo gets a filled rectangular background with this color. Use 'transparent'
          if your logo already has its own backdrop. Default = same as backgroundColor */
   logoBackgroundColor?: string;
-  /* If the logo is provided via SVG this color will be set as it's `fill` property
-  * it does nothing if logo is provided as an Image source object */
+  /* If the logo is provided via `logoSVG` prop, this color will be set as it's `fill` property,
+  * otherwise it does nothing */
   logoColor?: string;
   /* logo's distance to its wrapper */
   logoMargin?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { Image, ImageSourcePropType } from "react-native";
+import {ImageSourcePropType} from "react-native";
+import type {SvgProps} from "react-native-svg";
 
 declare class QRCode extends React.PureComponent<QRCodeProps, any> {}
 
@@ -12,6 +13,9 @@ export interface QRCodeProps {
   color?: string;
   /* the color of the background */
   backgroundColor?: string;
+  /* SVG to render as logo.
+  * If this prop is provided then `logo` prop will be ignored. */
+  logoSVG?: React.FC<SvgProps>;
   /* an image source object. example {uri: 'base64string'} or {require('pathToImage')} */
   logo?: ImageSourcePropType;
   /* logo size in pixels */
@@ -19,6 +23,9 @@ export interface QRCodeProps {
   /* the logo gets a filled rectangular background with this color. Use 'transparent'
          if your logo already has its own backdrop. Default = same as backgroundColor */
   logoBackgroundColor?: string;
+  /* If the logo is provided via SVG this color will be set as it's `fill` property
+  * it does nothing if logo is provided as an Image source object */
+  logoColor?: string;
   /* logo's distance to its wrapper */
   logoMargin?: number;
   /* the border-radius of logo image */

--- a/src/LogoSVG/index.js
+++ b/src/LogoSVG/index.js
@@ -1,0 +1,10 @@
+import React from 'react'
+
+const LogoSVG = ({ svg, logoSize, logoColor }) => {
+    // the svg prop is actually a svg wrapped in a React component, so for the web we can just render it
+    const LogoSVGComponent = svg;
+
+    return <LogoSVGComponent fill={logoColor} width={logoSize} height={logoSize} />;
+}
+
+export default LogoSVG;

--- a/src/LogoSVG/index.js
+++ b/src/LogoSVG/index.js
@@ -1,22 +1,22 @@
-import React from 'react'
-import {Image} from "react-native-svg";
-import {isString, isUrlString} from "../utils";
+import React from "react";
+import { Image } from "react-native-svg";
+import { isString, isUrlString } from "../utils";
 
 const LogoSVG = ({ svg, logoSize, logoColor }) => {
-    if(isString(svg)) {
-        const href = isUrlString(svg) ? svg : `data:image/svg+xml;base64,${window.btoa(svg)}`;
+  if (isString(svg)) {
+    const href = isUrlString(svg)
+      ? svg
+      : `data:image/svg+xml;base64,${window.btoa(svg)}`;
 
-        return <Image
-            href={encodeURI(href)}
-            width={logoSize}
-            height={logoSize}
-        />
-    }
+    return <Image href={encodeURI(href)} width={logoSize} height={logoSize} />;
+  }
 
-    // if `svg` prop is actually a svg asset wrapped in a React component, then we can just render it
-    const LogoSVGComponent = svg;
+  // if `svg` prop is actually a svg asset wrapped in a React component, then we can just render it
+  const LogoSVGComponent = svg;
 
-    return <LogoSVGComponent fill={logoColor} width={logoSize} height={logoSize} />;
-}
+  return (
+    <LogoSVGComponent fill={logoColor} width={logoSize} height={logoSize} />
+  );
+};
 
 export default LogoSVG;

--- a/src/LogoSVG/index.js
+++ b/src/LogoSVG/index.js
@@ -1,7 +1,19 @@
 import React from 'react'
+import {Image} from "react-native-svg";
+import {isString, isUrlString} from "../utils";
 
 const LogoSVG = ({ svg, logoSize, logoColor }) => {
-    // the svg prop is actually a svg wrapped in a React component, so for the web we can just render it
+    if(isString(svg)) {
+        const href = isUrlString(svg) ? svg : `data:image/svg+xml;base64,${window.btoa(svg)}`;
+
+        return <Image
+            href={encodeURI(href)}
+            width={logoSize}
+            height={logoSize}
+        />
+    }
+
+    // if `svg` prop is actually a svg asset wrapped in a React component, then we can just render it
     const LogoSVGComponent = svg;
 
     return <LogoSVGComponent fill={logoColor} width={logoSize} height={logoSize} />;

--- a/src/LogoSVG/index.native.js
+++ b/src/LogoSVG/index.native.js
@@ -1,7 +1,17 @@
 import React from 'react'
 import {LocalSvg} from 'react-native-svg/css'
+import {SvgUri, SvgXml} from "react-native-svg";
+import {isString, isUrlString} from "../utils";
 
 const LogoSVG = ({ svg, logoSize, logoColor }) => {
+    if (isString(svg)) {
+        if (isUrlString(svg)) {
+            return <SvgUri uri={svg} fill={logoColor} width={logoSize} height={logoSize} />
+        }
+
+        return <SvgXml xml={svg} fill={logoColor} width={logoSize} height={logoSize} />;
+    }
+
     return <LocalSvg asset={svg} fill={logoColor} width={logoSize} height={logoSize} />;
 }
 

--- a/src/LogoSVG/index.native.js
+++ b/src/LogoSVG/index.native.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import {LocalSvg} from 'react-native-svg/css'
+
+const LogoSVG = ({ svg, logoSize, logoColor }) => {
+    return <LocalSvg asset={svg} fill={logoColor} width={logoSize} height={logoSize} />;
+}
+
+export default LogoSVG;

--- a/src/LogoSVG/index.native.js
+++ b/src/LogoSVG/index.native.js
@@ -1,18 +1,24 @@
-import React from 'react'
-import {LocalSvg} from 'react-native-svg/css'
-import {SvgUri, SvgXml} from "react-native-svg";
-import {isString, isUrlString} from "../utils";
+import React from "react";
+import { LocalSvg } from "react-native-svg/css";
+import { SvgUri, SvgXml } from "react-native-svg";
+import { isString, isUrlString } from "../utils";
 
 const LogoSVG = ({ svg, logoSize, logoColor }) => {
-    if (isString(svg)) {
-        if (isUrlString(svg)) {
-            return <SvgUri uri={svg} fill={logoColor} width={logoSize} height={logoSize} />
-        }
-
-        return <SvgXml xml={svg} fill={logoColor} width={logoSize} height={logoSize} />;
+  if (isString(svg)) {
+    if (isUrlString(svg)) {
+      return (
+        <SvgUri uri={svg} fill={logoColor} width={logoSize} height={logoSize} />
+      );
     }
 
-    return <LocalSvg asset={svg} fill={logoColor} width={logoSize} height={logoSize} />;
-}
+    return (
+      <SvgXml xml={svg} fill={logoColor} width={logoSize} height={logoSize} />
+    );
+  }
+
+  return (
+    <LocalSvg asset={svg} fill={logoColor} width={logoSize} height={logoSize} />
+  );
+};
 
 export default LogoSVG;

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ import LogoSVG from "./LogoSVG";
 
 const renderLogo = ({
   size,
+  backgroundColor,
   logo,
   logoSVG,
   logoSize,
@@ -54,15 +55,18 @@ const renderLogo = ({
         <Rect
           width={logoBackgroundSize}
           height={logoBackgroundSize}
-          fill={logoBackgroundColor}
+          fill={backgroundColor}
           clipPath="url(#clip-logo-background)"
         />
       </G>
-      <G x={logoMargin} y={logoMargin}>
+      <G x={logoMargin} y={logoMargin} clipPath='url(#clip-logo)'>
+        <Rect
+            width={logoBackgroundSize - logoMargin}
+            height={logoBackgroundSize - logoMargin}
+            fill={logoBackgroundColor}
+        />
         {logoSVG ? (
-          <G clipPath="url(#clip-logo)">
             <LogoSVG svg={logoSVG} logoSize={logoSize} logoColor={logoColor} />
-          </G>
         ) : (
           <Image
             width={logoSize}
@@ -86,7 +90,7 @@ const QRCode = ({
   logoSVG,
   logoSize = size * 0.2,
   logoBackgroundColor = "transparent",
-  logoColor = "#000000",
+  logoColor,
   logoMargin = 2,
   logoBorderRadius = 0,
   quietZone = 0,
@@ -163,6 +167,7 @@ const QRCode = ({
       {displayLogo &&
         renderLogo({
           size,
+          backgroundColor,
           logo,
           logoSVG,
           logoSize,

--- a/src/index.js
+++ b/src/index.js
@@ -59,14 +59,14 @@ const renderLogo = ({
           clipPath="url(#clip-logo-background)"
         />
       </G>
-      <G x={logoMargin} y={logoMargin} clipPath='url(#clip-logo)'>
+      <G x={logoMargin} y={logoMargin} clipPath="url(#clip-logo)">
         <Rect
-            width={logoBackgroundSize - logoMargin}
-            height={logoBackgroundSize - logoMargin}
-            fill={logoBackgroundColor}
+          width={logoBackgroundSize - logoMargin}
+          height={logoBackgroundSize - logoMargin}
+          fill={logoBackgroundColor}
         />
         {logoSVG ? (
-            <LogoSVG svg={logoSVG} logoSize={logoSize} logoColor={logoColor} />
+          <LogoSVG svg={logoSVG} logoSize={logoSize} logoColor={logoColor} />
         ) : (
           <Image
             width={logoSize}

--- a/src/index.js
+++ b/src/index.js
@@ -1,150 +1,178 @@
-global.TextEncoder = require('text-encoding').TextEncoder;
+global.TextEncoder = require("text-encoding").TextEncoder;
 
-import React, { useMemo } from 'react';
-import Svg, { Defs, G, Path, Rect, Image, ClipPath, LinearGradient, Stop } from 'react-native-svg';
-import genMatrix from './genMatrix';
-import transformMatrixIntoPath from './transformMatrixIntoPath';
+import React, { useMemo } from "react";
+import Svg, {
+  Defs,
+  G,
+  Path,
+  Rect,
+  Image,
+  ClipPath,
+  LinearGradient,
+  Stop,
+} from "react-native-svg";
+import genMatrix from "./genMatrix";
+import transformMatrixIntoPath from "./transformMatrixIntoPath";
+import LogoSVG from "./LogoSVG";
 
 const renderLogo = ({
-    size,
-    logo,
-    logoSize,
-    logoBackgroundColor,
-    logoMargin,
-    logoBorderRadius,
+  size,
+  logo,
+  logoSVG,
+  logoSize,
+  logoBackgroundColor,
+  logoColor,
+  logoMargin,
+  logoBorderRadius,
 }) => {
-    const logoPosition = (size - logoSize - logoMargin * 2) / 2;
-    const logoBackgroundSize = logoSize + logoMargin * 2;
-    const logoBackgroundBorderRadius =
-        logoBorderRadius + (logoMargin / logoSize) * logoBorderRadius;
+  const logoPosition = (size - logoSize - logoMargin * 2) / 2;
+  const logoBackgroundSize = logoSize + logoMargin * 2;
+  const logoBackgroundBorderRadius =
+    logoBorderRadius + (logoMargin / logoSize) * logoBorderRadius;
 
-    return (
-        <G x={logoPosition} y={logoPosition}>
-            <Defs>
-                <ClipPath id='clip-logo-background'>
-                    <Rect
-                        width={logoBackgroundSize}
-                        height={logoBackgroundSize}
-                        rx={logoBackgroundBorderRadius}
-                        ry={logoBackgroundBorderRadius}
-                    />
-                </ClipPath>
-                <ClipPath id='clip-logo'>
-                    <Rect
-                        width={logoSize}
-                        height={logoSize}
-                        rx={logoBorderRadius}
-                        ry={logoBorderRadius}
-                    />
-                </ClipPath>
-            </Defs>
-            <G>
-                <Rect
-                    width={logoBackgroundSize}
-                    height={logoBackgroundSize}
-                    fill={logoBackgroundColor}
-                    clipPath='url(#clip-logo-background)'
-                />
-            </G>
-            <G x={logoMargin} y={logoMargin}>
-                <Image
-                    width={logoSize}
-                    height={logoSize}
-                    preserveAspectRatio='xMidYMid slice'
-                    href={logo}
-                    clipPath='url(#clip-logo)'
-                />
-            </G>
-        </G>
-    );
+  return (
+    <G x={logoPosition} y={logoPosition}>
+      <Defs>
+        <ClipPath id="clip-logo-background">
+          <Rect
+            width={logoBackgroundSize}
+            height={logoBackgroundSize}
+            rx={logoBackgroundBorderRadius}
+            ry={logoBackgroundBorderRadius}
+          />
+        </ClipPath>
+        <ClipPath id="clip-logo">
+          <Rect
+            width={logoSize}
+            height={logoSize}
+            rx={logoBorderRadius}
+            ry={logoBorderRadius}
+          />
+        </ClipPath>
+      </Defs>
+      <G>
+        <Rect
+          width={logoBackgroundSize}
+          height={logoBackgroundSize}
+          fill={logoBackgroundColor}
+          clipPath="url(#clip-logo-background)"
+        />
+      </G>
+      <G x={logoMargin} y={logoMargin}>
+        {logoSVG ? (
+          <G clipPath="url(#clip-logo)">
+            <LogoSVG svg={logoSVG} logoSize={logoSize} logoColor={logoColor} />
+          </G>
+        ) : (
+          <Image
+            width={logoSize}
+            height={logoSize}
+            preserveAspectRatio="xMidYMid slice"
+            href={logo}
+            clipPath="url(#clip-logo)"
+          />
+        )}
+      </G>
+    </G>
+  );
 };
 
 const QRCode = ({
-  value = 'this is a QR code',
+  value = "this is a QR code",
   size = 100,
-  color = 'black',
-  backgroundColor = 'white',
+  color = "black",
+  backgroundColor = "white",
   logo,
+  logoSVG,
   logoSize = size * 0.2,
-  logoBackgroundColor = 'transparent',
+  logoBackgroundColor = "transparent",
+  logoColor = "#000000",
   logoMargin = 2,
   logoBorderRadius = 0,
   quietZone = 0,
   enableLinearGradient = false,
-  gradientDirection = ['0%', '0%', '100%', '100%'],
-  linearGradient = ['rgb(255,0,0)', 'rgb(0,255,255)'],
-  ecl = 'M',
+  gradientDirection = ["0%", "0%", "100%", "100%"],
+  linearGradient = ["rgb(255,0,0)", "rgb(0,255,255)"],
+  ecl = "M",
   getRef,
   onError,
-  testID
+  testID,
 }) => {
-    const result = useMemo(() => {
-        try {
-            return transformMatrixIntoPath(genMatrix(value, ecl), size);
-        } catch (error) {
-            if (onError && typeof onError === 'function') {
-                onError(error);
-            } else {
-                // Pass the error when no handler presented
-                throw error;
-            }
-        }
-    }, [value, size, ecl]);
-
-    if (!result) {
-        return null;
+  const result = useMemo(() => {
+    try {
+      return transformMatrixIntoPath(genMatrix(value, ecl), size);
+    } catch (error) {
+      if (onError && typeof onError === "function") {
+        onError(error);
+      } else {
+        // Pass the error when no handler presented
+        throw error;
+      }
     }
+  }, [value, size, ecl]);
 
-    const { path, cellSize } = result;
+  if (!result) {
+    return null;
+  }
 
-    return (
-        <Svg
-            testID={testID}
-            ref={getRef}
-            viewBox={[-quietZone, -quietZone, size + quietZone * 2, size + quietZone * 2].join(' ')}
-            width={size}
-            height={size}
+  const { path, cellSize } = result;
+  const displayLogo = logo || logoSVG;
+
+  return (
+    <Svg
+      testID={testID}
+      ref={getRef}
+      viewBox={[
+        -quietZone,
+        -quietZone,
+        size + quietZone * 2,
+        size + quietZone * 2,
+      ].join(" ")}
+      width={size}
+      height={size}
+    >
+      <Defs>
+        <LinearGradient
+          id="grad"
+          x1={gradientDirection[0]}
+          y1={gradientDirection[1]}
+          x2={gradientDirection[2]}
+          y2={gradientDirection[3]}
         >
-            <Defs>
-                <LinearGradient
-                    id='grad'
-                    x1={gradientDirection[0]}
-                    y1={gradientDirection[1]}
-                    x2={gradientDirection[2]}
-                    y2={gradientDirection[3]}
-                >
-                    <Stop offset='0' stopColor={linearGradient[0]} stopOpacity='1' />
-                    <Stop offset='1' stopColor={linearGradient[1]} stopOpacity='1' />
-                </LinearGradient>
-            </Defs>
-            <G>
-                <Rect
-                    x={-quietZone}
-                    y={-quietZone}
-                    width={size + quietZone * 2}
-                    height={size + quietZone * 2}
-                    fill={backgroundColor}
-                />
-            </G>
-            <G>
-                <Path
-                    d={path}
-                    strokeLinecap='butt'
-                    stroke={enableLinearGradient ? 'url(#grad)' : color}
-                    strokeWidth={cellSize}
-                />
-            </G>
-            {logo &&
-                renderLogo({
-                    size,
-                    logo,
-                    logoSize,
-                    logoBackgroundColor,
-                    logoMargin,
-                    logoBorderRadius,
-                })}
-        </Svg>
-    );
+          <Stop offset="0" stopColor={linearGradient[0]} stopOpacity="1" />
+          <Stop offset="1" stopColor={linearGradient[1]} stopOpacity="1" />
+        </LinearGradient>
+      </Defs>
+      <G>
+        <Rect
+          x={-quietZone}
+          y={-quietZone}
+          width={size + quietZone * 2}
+          height={size + quietZone * 2}
+          fill={backgroundColor}
+        />
+      </G>
+      <G>
+        <Path
+          d={path}
+          strokeLinecap="butt"
+          stroke={enableLinearGradient ? "url(#grad)" : color}
+          strokeWidth={cellSize}
+        />
+      </G>
+      {displayLogo &&
+        renderLogo({
+          size,
+          logo,
+          logoSVG,
+          logoSize,
+          logoBackgroundColor,
+          logoColor,
+          logoMargin,
+          logoBorderRadius,
+        })}
+    </Svg>
+  );
 };
 
 export default QRCode;

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,7 @@
+export function isString(variable) {
+    return typeof variable === "string";
+}
+
+export function isUrlString(variable) {
+    return isString(variable) && variable.startsWith("http");
+}


### PR DESCRIPTION
# Problem
In current version of this library only image assets (like `*.png` and other raster images) can be used as a logo image within QR code. Using an SVG asset for the logo is not possible.

# Solution
This PR tries to make it possible to use svgs in said logo image.

I have not found any reasonable way to do this via a single `logo` prop, as there is no React component that could accept either `ImageSourcePropType` or an `SVG` and handle every case correctly. Some conditional logic is required to handle the svg prop, thats why I decided to add it as a new prop, while the old logo prop will work unchanged.
That makes this new functionality backwards compatible. If you won't use new `logoSVG` prop - the library will work as it used to.

# Done
 - add (optional) `logoSVG` prop that accepts an svg and will render it
 - add (optional) `logoColor` prop to set the `fill` property of the svg logo
 - this solution handles: 
   - a string svg, ex: `"<svg ....>"`
   - an URL pointing to an svg image, ex: https://raw.githubusercontent.com/software-mansion/react-native-svg/4b51a41a22432030a3396e847dc7d5aec5a86ae9/TestsExample/assets/ruby.svg
   - an svg React component - this is a popular format that one can get via using `@svgr/webpack` - which allows one to load SVGs directly using `import` and webpack will handle them by transforming into functional component that returns na svg
 - on web we will either render the svg logo if its a component OR in case of string we use standard `Image` from `react-native-svg`
 - on native ios/android we use special dedicated components from `react-native-svg` which will handle all these cases

# Examples

## ios and android
<p>
<img width="350" alt="Screenshot 2024-08-26 at 11 57 50" src="https://github.com/user-attachments/assets/6ff855ed-5cee-4e13-bfd3-e71b7ffc1c5c">
<img width="350" alt="Screenshot 2024-08-26 at 11 58 02" src="https://github.com/user-attachments/assets/bfc58479-dae7-45cc-a95a-70e2ca586b55">
</p>

## web
![Screenshot 2024-08-26 at 13 02 13](https://github.com/user-attachments/assets/b3dc3a84-fe8e-4668-88cb-b945de3939e4)


