### PR TITLE
Add missing index.html for web version to work

### DIFF
--- a/Example/dist/index.html
+++ b/Example/dist/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>react-native-qrcode-svg example</title>
+    <style>
+        html,
+        body {
+            height: 100%;
+        }
+        #root {
+            display: flex;
+            height: 100%;
+        }
+    </style>
+</head>
+
+<body>
+<noscript>You need to enable JavaScript to run this app.</noscript>
+<div id="root"></div>
+<script src="bundle.web.js"></script>
+</body>
+</html>


### PR DESCRIPTION
I made a small mistake when adding `Example` app and I missed adding the base `index.html` which made the web version not work.

This PR adds it. No change to api or app logic, this code only concerns Example app which is a tool for devs.