### PR TITLE
Cut out the logo if the QR and logo background are transparent

### DIFF
--- a/Example/src/App.tsx
+++ b/Example/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {SafeAreaView, ScrollView, Text} from 'react-native';
+import {SafeAreaView, ScrollView, Text, View} from 'react-native';
 import SVG from './assets/ruby.svg';
 import Description from './components/Description';
 import QRCode from 'react-native-qrcode-svg';
@@ -47,6 +47,21 @@ const localPngQRCode = (
       logo={require('./assets/google.png')}
       logoSize={logoSize}
     />
+  </Description>
+);
+
+const localTransparentPngQRCode = (
+  <Description text="QR code with local transparent PNG">
+    <View style={{backgroundColor: 'blue'}}>
+      <QRCode
+        value={googleUrl}
+        size={qrCodeSize}
+        logo={require('./assets/google.png')}
+        logoSize={logoSize}
+        logoBackgroundColor="transparent"
+        backgroundColor="transparent"
+      />
+    </View>
   </Description>
 );
 
@@ -119,6 +134,7 @@ const App = () => {
         {colorfulQRCODe}
         {urlPngQRCode}
         {localPngQRCode}
+        {localTransparentPngQRCode}
         {localPngBackgroundColorQRCode}
         {urlSvgQRCode}
         {stringSvgQRCode}

--- a/src/index.js
+++ b/src/index.js
@@ -122,6 +122,9 @@ const QRCode = ({
   const { path, cellSize } = result;
   const displayLogo = logo || logoSVG;
 
+  const logoPosition = (size - logoSize - logoMargin * 2) / 2;
+  const logoPositionEnd = logoPosition + logoSize + logoMargin * 2;
+
   return (
     <Svg
       testID={testID}
@@ -146,6 +149,12 @@ const QRCode = ({
           <Stop offset="0" stopColor={linearGradient[0]} stopOpacity="1" />
           <Stop offset="1" stopColor={linearGradient[1]} stopOpacity="1" />
         </LinearGradient>
+        <ClipPath id="invert-clip-logo">
+          <Path
+            d={`M0,0 L${size},0 L${size},${size} L0,${size} Z
+                 M${logoPosition},${logoPosition} L${logoPosition},${logoPositionEnd} L${logoPositionEnd},${logoPositionEnd} L${logoPositionEnd},${logoPosition} Z`}
+          />
+        </ClipPath>
       </Defs>
       <G>
         <Rect
@@ -162,6 +171,12 @@ const QRCode = ({
           strokeLinecap="butt"
           stroke={enableLinearGradient ? "url(#grad)" : color}
           strokeWidth={cellSize}
+          clipPath={
+            displayLogo &&
+            logoBackgroundColor === "transparent" &&
+            backgroundColor === "transparent" &&
+            "url(#invert-clip-logo)"
+          }
         />
       </G>
       {displayLogo &&


### PR DESCRIPTION
Fixes https://github.com/Expensify/react-native-qrcode-svg/issues/211

### Before

<img width="372" alt="Screenshot 2024-08-28 at 9 20 44 PM" src="https://github.com/user-attachments/assets/25f396e1-92f0-40d3-8d4f-ed6df84bed5b">

### After

<img width="371" alt="Screenshot 2024-08-28 at 9 20 54 PM" src="https://github.com/user-attachments/assets/1d6fda43-6483-4411-bfae-b9249b6f699d">

The code could use a cleanup but the clip-path is correct as far as I can tell. It also doesn't handle border radius very well :/
