### PR TITLE
Dependency Fix : Android app crushed when use version 6.1.1 #204

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   "dependencies": {
     "prop-types": "^15.8.0",
     "qrcode": "^1.5.1",
-    "text-encoding": "^0.7.0"
+    "fast-text-encoding": "^1.0.6"
+
   },
   "devDependencies": {
     "@types/react": "^18.2.75",

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-global.TextEncoder = require("text-encoding").TextEncoder;
+global.TextEncoder = require("fast-text-encoding").TextEncoder;
 
 import React, { useMemo } from "react";
 import Svg, {


### PR DESCRIPTION
Text Encoder from `text-encoding` cause Issue with "The Property 'TextEncoder' is not exist"
. Fixed with the updated text-encoder library