### PR TITLE
Remove build step from npm publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,9 +54,6 @@ jobs:
             - name: Push branch and publish tags
               run: git push origin main && git push --tags
 
-            - name: Build package
-              run: npm run build
-
             - name: Publish to npm
               run: npm publish
               env:


### PR DESCRIPTION
Coming from the [latest workflow run](https://github.com/Expensify/react-native-qrcode-svg/actions/runs/10586099259/job/30410660739), the workflow is failing with:

```
npm error Missing script: "build"
```

The previous [npmpublish.yml](https://github.com/Expensify/react-native-qrcode-svg/pull/210/files#diff-982aa7638644ab2313c558c13644ffd0dd5c967b1da790524de7624c698c6647) workflow only had the following steps:

1. setup node
2. npm ci
3. npm test
4. npm publish

So I'm removing the `npm run build` step since it doesn't seem like we need to bundle this lib. cc @Kicu 