### PR TITLE
Extend QRCodeProps value type to include mode options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,7 +6,7 @@ declare class QRCode extends React.PureComponent<QRCodeProps, any> {}
 
 export interface QRCodeProps {
   /* what the qr code stands for */
-  value?: string;
+  value?: string | Array<{data: string; mode: 'alphanumeric' | 'numeric' | 'byte' | 'kanji' | 'mixed';}>;
   /* the whole component size */
   size?: number;
   /* the color of the cell */


### PR DESCRIPTION
This PR modifies the QRCodeProps interface in index.d.ts to support an array of objects specifying data and mode, accommodating modes such as 'alphanumeric', 'numeric', 'byte', 'kanji', and 'mixed'.