### PR TITLE
Removed the text-encondig code line

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Here's how to configure the transformer for both Expo and React Native projects:
 #### Setting Up the Transformer:
 Make sure your project has a `metro.config.js` file. If not, create one at the root of your project.
 
+#### Expo Projects:
 ```js
 const { getDefaultConfig } = require("expo/metro-config");
 
@@ -190,14 +191,13 @@ module.exports = (() => {
   return config;
 })();
 ```
-Merge the contents from your project's metro.config.js file with this config (create the file if it does not exist already).
+Merge the contents from your project's metro.config.js file with this config.
 
+#### React Native Projects:
 ```js
 const { getDefaultConfig, mergeConfig } = require("@react-native/metro-config");
 
 const defaultConfig = getDefaultConfig(__dirname);
-
-const { assetExts, sourceExts } = defaultConfig.resolver;
 
 const config = {
   transformer: {

--- a/README.md
+++ b/README.md
@@ -165,3 +165,46 @@ Read more details in the dedicated [README](/Example/README.md).
 ### Dependencies
 
 * [node-qrcode](https://github.com/soldair/node-qrcode)
+
+### Integrating react-native-qrcode-svg with React Native versions below 0.75
+This library works seamlessly with React Native versions 0.75 and above. However, if you're using an older version of React Native (below 0.75), you might need to apply a custom transformation to your project's metro.config.js file to ensure compatibility with the TextEncoder API.
+
+Here's how to configure the transformer for both Expo and React Native projects:
+
+#### Setting Up the Transformer:
+Make sure your project has a `metro.config.js` file. If not, create one at the root of your project.
+
+```js
+const { getDefaultConfig } = require("expo/metro-config");
+
+module.exports = (() => {
+  const config = getDefaultConfig(__dirname);
+
+  const { transformer } = config;
+
+  config.transformer = {
+    ...transformer,
+    babelTransformerPath: require.resolve("react-native-qrcode-svg/textEncodingTransformation")
+  };
+
+  return config;
+})();
+```
+Merge the contents from your project's metro.config.js file with this config (create the file if it does not exist already).
+
+```js
+const { getDefaultConfig, mergeConfig } = require("@react-native/metro-config");
+
+const defaultConfig = getDefaultConfig(__dirname);
+
+const { assetExts, sourceExts } = defaultConfig.resolver;
+
+const config = {
+  transformer: {
+    babelTransformerPath: require.resolve("react-native-qrcode-svg/textEncodingTransformation"),
+  },
+};
+
+module.exports = mergeConfig(defaultConfig, config);
+```
+

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,9 @@
 module.exports = {
-  presets: ["module:metro-react-native-babel-preset"],
+  presets: 
+  [
+    "module:metro-react-native-babel-preset", 
+    {
+      disableImportExportTransform: true,
+    },
+  ],
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-qrcode-svg",
-  "version": "6.3.12",
+  "version": "6.3.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-qrcode-svg",
-      "version": "6.3.12",
+      "version": "6.3.13",
       "license": "MIT",
       "dependencies": {
         "prop-types": "^15.8.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "src",
     "babel.config.js",
     "index.d.ts",
-    "index.js"
+    "index.js",
+    "textEncodingTransformation.js"
   ],
   "keywords": [
     "react-native",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-qrcode-svg",
-  "version": "6.3.12",
+  "version": "6.3.13",
   "description": "A QR Code generator for React Native based on react-native-svg and javascript-qrcode.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,3 @@
-global.TextEncoder = require("text-encoding").TextEncoder;
-
 import React, { useMemo } from "react";
 import Svg, {
   Defs,

--- a/textEncodingTransformation.js
+++ b/textEncodingTransformation.js
@@ -1,4 +1,5 @@
 const { readFileSync } = require('fs');
+const semver = require('semver');
 
 const fileToTransform = 'node_modules/react-native-qrcode-svg/src/index.js';
 
@@ -20,11 +21,10 @@ function createTransformer(transformer) {
         const packageJsonPath = require.resolve('react-native/package.json');
         const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
         const ReactNativeVersion = packageJson.version;
-        const [major, minor] = ReactNativeVersion.split('.');
 
         // React Native versions below 0.75 do not include a global TextEncoder implementation.
         // To ensure compatibility with these older versions, we add a polyfill using the 'text-encoding' library.
-        if (major === '0' && minor < '75') {
+        if (semver.lt(ReactNativeVersion, '0.75.0')) {
             return transformer.transform({
                 src: `global.TextEncoder = require('text-encoding').TextEncoder;\n${src}`, 
                 filename, 

--- a/textEncodingTransformation.js
+++ b/textEncodingTransformation.js
@@ -1,0 +1,41 @@
+const { readFileSync } = require('fs');
+
+const fileToTransform = 'node_modules/react-native-qrcode-svg/src/index.js';
+
+const upstreamTransformer = (() => {
+    try {
+      return require("@expo/metro-config/babel-transformer");
+    } catch (error) {
+      try {
+        return require("@react-native/metro-babel-transformer");
+      } catch (error) {
+        return require("metro-react-native-babel-transformer");
+      }
+    }
+  })();
+
+function createTransformer(transformer) {
+    return async ({src, filename, ...rest}) => {
+      if (filename === fileToTransform) {
+        const packageJsonPath = require.resolve('react-native/package.json');
+        const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+        const ReactNativeVersion = packageJson.version;
+        const [major, minor] = ReactNativeVersion.split('.');
+
+        // React Native versions below 0.75 do not include a global TextEncoder implementation.
+        // To ensure compatibility with these older versions, we add a polyfill using the 'text-encoding' library.
+        if (major === '0' && minor < '75') {
+            return transformer.transform({
+                src: `global.TextEncoder = require('text-encoding').TextEncoder;\n${src}`, 
+                filename, 
+                ...rest
+            });
+        }
+      }
+      return transformer.transform({src, filename, ...rest});
+    };
+}
+
+module.exports = {
+    transform: createTransformer(upstreamTransformer),
+};


### PR DESCRIPTION
## Details
<!-- Explanation of the change or anything fishy that is going on -->
Adds a custom transformer to support React Native versions below 0.75, which require the TextEncoder polyfill. The transformer modifies the src/index.js file of the library to include the necessary polyfill.

## What this fixes
<!--
  Any details about the bug this fixes (if there was any).
  Related issues (if there were any).
-->
This PR addresses an issue where the `text-encoding` library was being included unnecessarily in the bundle for React Native versions 0.75 and above. By conditionally adding the polyfill only when needed, this change reduces the bundle size and improves performance. 

## Checklist
- [x] I have described the bug/issue
- [x] I have provided reproduction in `Example` App
- [x] I have tested that solution works on `Example` App on all platforms:
  - Android
  - iOS
  - Web

### Screenshots/Videos
<!-- Any extra screens related to your solution -->

<img width="408" alt="Screenshot 2024-12-20 at 17 59 26" src="https://github.com/user-attachments/assets/9eedd218-9b98-4917-940e-b6fa6aec503b" />

