### PR TITLE
Fix repo url

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/awesomejerry/react-native-qrcode-svg.git"
+    "url": "git+https://github.com/Expensify/react-native-qrcode-svg.git"
   },
   "files": [
     "Example",

--- a/package.json
+++ b/package.json
@@ -44,12 +44,12 @@
     "qrcode",
     "svg"
   ],
-  "author": "awesomejerry",
+  "author": "Expensify",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/awesomejerry/react-native-qrcode-svg/issues"
+    "url": "https://github.com/Expensify/react-native-qrcode-svg/issues"
   },
-  "homepage": "https://github.com/awesomejerry/react-native-qrcode-svg#readme",
+  "homepage": "https://github.com/Expensify/react-native-qrcode-svg#readme",
   "peerDependencies": {
     "react": "*",
     "react-native": ">=0.63.4",


### PR DESCRIPTION
## Details
Coming from [this thread](https://expensify.slack.com/archives/C06BDSWLDPB/p1739793644035839), we added provenance to the `npm publish` workflow, so we need to make sure the repo URL matches what npm expects

## What this fixes
https://expensify.slack.com/archives/C06BDSWLDPB/p1739793644035839
