### PR TITLE
Update react-native-svg repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Read more details in the dedicated [README](/Example/README.md).
 
 ### PeerDependencies
 
-* [react-native-svg](https://github.com/magicismight/react-native-svg)
+* [react-native-svg](https://github.com/software-mansion/react-native-svg)
 
 ### Dependencies
 


### PR DESCRIPTION
## Details
<!-- Explanation of the change or anything fishy that is going on -->
This is mainly an update to test the publishing via OIDC. The repo linked has migrated to a different owner, this fixes that so there is no more redirect.