### PR TITLE
fix: prevent SVG clip path ID collisions in multiple QR code instances

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useMemo, useId } from "react";
 import Svg, {
   Defs,
   G,
@@ -23,16 +23,19 @@ const renderLogo = ({
   logoColor,
   logoMargin,
   logoBorderRadius,
+  clipPathId
 }) => {
   const logoPosition = (size - logoSize - logoMargin * 2) / 2;
   const logoBackgroundSize = logoSize + logoMargin * 2;
   const logoBackgroundBorderRadius =
     logoBorderRadius + (logoMargin / logoSize) * logoBorderRadius;
-
+  const clipLogoBackgroundId = `clip-logo-background-${clipPathId}`;
+  const clipLogoId = `clip-logo-${clipPathId}`;
+  
   return (
     <G x={logoPosition} y={logoPosition}>
       <Defs>
-        <ClipPath id="clip-logo-background">
+        <ClipPath id={clipLogoBackgroundId}>
           <Rect
             width={logoBackgroundSize}
             height={logoBackgroundSize}
@@ -40,7 +43,7 @@ const renderLogo = ({
             ry={logoBackgroundBorderRadius}
           />
         </ClipPath>
-        <ClipPath id="clip-logo">
+        <ClipPath id={clipLogoId}>
           <Rect
             width={logoSize}
             height={logoSize}
@@ -54,10 +57,10 @@ const renderLogo = ({
           width={logoBackgroundSize}
           height={logoBackgroundSize}
           fill={backgroundColor}
-          clipPath="url(#clip-logo-background)"
+          clipPath={`url(#${clipLogoBackgroundId})`}
         />
       </G>
-      <G x={logoMargin} y={logoMargin} clipPath="url(#clip-logo)">
+      <G x={logoMargin} y={logoMargin} clipPath={`url(#${clipLogoId})`}>
         <Rect
           width={logoBackgroundSize - logoMargin}
           height={logoBackgroundSize - logoMargin}
@@ -71,7 +74,7 @@ const renderLogo = ({
             height={logoSize}
             preserveAspectRatio="xMidYMid slice"
             href={logo}
-            clipPath="url(#clip-logo)"
+            clipPath={`url(#${clipLogoId})`}
           />
         )}
       </G>
@@ -100,6 +103,8 @@ const QRCode = ({
   onError,
   testID,
 }) => {
+  const clipPathId = useId();
+
   const result = useMemo(() => {
     try {
       return transformMatrixIntoPath(genMatrix(value, ecl), size);
@@ -173,6 +178,7 @@ const QRCode = ({
           logoColor,
           logoMargin,
           logoBorderRadius,
+          clipPathId,
         })}
     </Svg>
   );


### PR DESCRIPTION
## Details
<!-- Explanation of the change or anything fishy that is going on -->
Integrated React's `useId` hook to generate unique clip path IDs for each QR logo component instance. Each QR logo now has unique identifiers for its SVG clip paths (`clip-logo-background-{id}` and `clip-logo-{id}`), preventing ID collisions when multiple QR codes are rendered on the same page.

## What this fixes
<!--
  Any details about the bug this fixes (if there was any).
  Related issues (if there were any).
-->
Issue: https://github.com/Expensify/App/issues/74794
Proposal: https://github.com/Expensify/App/issues/74794#issuecomment-3521050882

As shown in the screenshots below, the "Before" example demonstrates the bug: all QR code logos render with rounded even though the border radius is only specified for one logo. This happens because all instances share the same clip path IDs, causing the styling to leak across logo. After this fix, the border radius correctly applies only to the intended logo, while other logos remain unaffected.
## Checklist
- [x] I have described the bug/issue
- [x] I have provided reproduction in `Example` App
- [x] I have tested that solution works on `Example` App on all platforms:
  - Android
  - iOS
  - Web

### Screenshots/Videos
| Before                      | After                       |
|-----------------------------------------|-----------------------------------------|
| <video src="https://github.com/user-attachments/assets/bd8a08ba-1d67-47a9-a67b-4c4356cb4c41" width="100%" controls>|<video src="https://github.com/user-attachments/assets/aea87a27-39da-4f30-9a40-01a0033ea470" width="100%" controls>| |

