### PR TITLE
Remove committed .xcode.env.local with personal Node path

### DIFF
--- a/Example/macos/.xcode.env.local
+++ b/Example/macos/.xcode.env.local
@@ -1,2 +1,0 @@
-export NODE_BINARY=/Users/war-in/.nvm/versions/node/v20.10.0/bin/node
-


### PR DESCRIPTION
## Details
Removes `Example/macos/.xcode.env.local` from version control. The file contains a machine-specific Node binary path (`/Users/war-in/.nvm/versions/node/v20.10.0/bin/node`) and is already covered by the `**/.xcode.env.local` rule in `Example/.gitignore`, but it was committed anyway when the macOS example was added. Removed with `git rm --cached`, so the ignore rule now takes effect and each developer's local copy stays untracked.

## What this fixes
A committed `.xcode.env.local` overrides `NODE_BINARY` with a path that only exists on the original author's machine, which can break local macOS Example builds for everyone else. No related issue.

## Checklist
- [x] I have described the bug/issue
- [x] I have provided reproduction in `Example` App
- [x] I have tested that solution works on `Example` App on all platforms:
  - Android
  - iOS
  - Web

### Screenshots/Videos
N/A — removes an untracked-config file from git; no code or UI changes.
